### PR TITLE
amending wrapper to work with docker OR conda dependencies, adding info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ ImageJ-linux64 --ij2 --headless --run imagej_basic_ashlar.py \
   "filename='/data/input.ome.tiff',output_dir='/data/',experiment_name='my_experiment'"
 ```
 for each `input.ome.tiff` in your data directory.
+
+## Note for Galaxy admins
+Galaxy's default job configuration for local Docker execution does not deal with `ENTRYPOINT`s properly; please ensure you have the following line in your job configuration file's local Docker `<destination>` block:
+```
+<param id="docker_run_extra_arguments">&#45;&#45;entrypoint ""</param>
+```
+
+This parameter (`--entrypoint ""`) nullifies the `ENTRYPOINT`, allowing the `CMD` to be overwritten by Galaxy, and Galaxy's generated `tool_script.sh` to be executed as expected.

--- a/basic_illumination.xml
+++ b/basic_illumination.xml
@@ -12,6 +12,13 @@
 
     #set $outname = str($in_files.name).replace('.ome.tiff','')
 
+    ## if ImageJ isn't already present, this is the docker-dependency version
+    ## as such, ImageJ needs to be registered as a global executable on $PATH
+    if ! [ -x "\$(which ImageJ)" ]; then
+	    ln -sf "\$(which ImageJ-linux64)" "ImageJ";
+        export PATH="\$PATH:\$(pwd)/";
+    fi;
+
     @CMD_BEGIN@
 
     "filename='${in_files.name}',output_dir='.',experiment_name='output'";


### PR DESCRIPTION
this PR adds:
- symlink logic to make tool invocation look the same between docker and conda dependencies so the script can use the same commands
- README info for Galaxy admins

Notes:
- both Docker and Conda dependency resolution tested